### PR TITLE
fix: assign strutStyle property in ExtendedText factory

### DIFF
--- a/lib/src/extended_rich_text.dart
+++ b/lib/src/extended_rich_text.dart
@@ -160,11 +160,7 @@ class ExtendedRichText extends MultiChildRenderObjectWidget {
       maxLines: maxLines,
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis,
-      locale: locale ??
-          Localizations.localeOf(
-            context,
-            nullOk: true,
-          ),
+      locale: locale ?? Localizations.maybeLocaleOf(context),
       selection: selection,
       onSelectionChanged: onSelectionChanged,
       selectionColor: selectionColor,
@@ -193,7 +189,7 @@ class ExtendedRichText extends MultiChildRenderObjectWidget {
       ..maxLines = maxLines
       ..strutStyle = strutStyle
       ..textWidthBasis = textWidthBasis
-      ..locale = locale ?? Localizations.localeOf(context, nullOk: true)
+      ..locale = locale ?? Localizations.maybeLocaleOf(context)
       ..selection = selection
       ..selectionColor = selectionColor
       ..onSelectionChanged = onSelectionChanged

--- a/lib/src/extended_text.dart
+++ b/lib/src/extended_text.dart
@@ -251,6 +251,7 @@ class ExtendedText extends StatelessWidget {
             textHeightBehavior ?? defaultTextStyle.textHeightBehavior,
         textWidthBasis: textWidthBasis ?? defaultTextStyle.textWidthBasis,
         overFlowWidget: overflowWidget,
+        strutStyle: strutStyle,
       );
     } else {
       result = ExtendedRichText(
@@ -271,6 +272,7 @@ class ExtendedText extends StatelessWidget {
         textWidthBasis: textWidthBasis ?? defaultTextStyle.textWidthBasis,
         overflowWidget: overflowWidget,
         hasFocus: false,
+        strutStyle: strutStyle,
       );
     }
 

--- a/lib/src/selection/extended_text_selection.dart
+++ b/lib/src/selection/extended_text_selection.dart
@@ -36,6 +36,7 @@ class ExtendedTextSelection extends StatefulWidget {
       this.selectionHeightStyle = BoxHeightStyle.tight,
       this.selectionWidthStyle = BoxWidthStyle.tight,
       this.overFlowWidget,
+      this.strutStyle,
       Key key})
       : assert(selectionHeightStyle != null),
         assert(selectionWidthStyle != null),
@@ -92,6 +93,9 @@ class ExtendedTextSelection extends StatefulWidget {
 
   /// How visual overflow should be handled.
   final TextOverflow overflow;
+
+  /// {@macro flutter.painting.textPainter.strutStyle}
+  final StrutStyle strutStyle;
 
   /// The number of font pixels for each logical pixel.
   ///
@@ -287,6 +291,7 @@ class ExtendedTextSelectionState extends State<ExtendedTextSelection>
                 overflowWidget: widget.overFlowWidget,
                 hasFocus: _effectiveFocusNode.hasFocus,
                 textSelectionDelegate: this,
+                strutStyle: widget.strutStyle,
               ),
             )));
 


### PR DESCRIPTION
`strutStyle` defined in `ExtendedText`, but never used in an actual text widget.