### PR TITLE
[Fix] - Selection Overlay Issue

### DIFF
--- a/lib/src/selection/extended_text_selection.dart
+++ b/lib/src/selection/extended_text_selection.dart
@@ -271,6 +271,7 @@ class ExtendedTextSelectionState extends State<ExtendedTextSelection>
     _focusNode?.dispose();
     _focusAttachment?.detach();
     _closeInputConnectionIfNeeded();
+    _selectionOverlay?.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
When i show the selection overlay, pop back to another screen without hide the overlay and then back to that screen then this error shows up.
 We should dispose on the selectionOverlay when the widget is not used anymore


![image](https://user-images.githubusercontent.com/50696626/174007413-491485d2-1e20-4c4a-a1ac-ea119928d1ce.png)
![image](https://user-images.githubusercontent.com/50696626/174007957-ef42703e-53c5-44b9-999f-d45bf6ccd856.png)
![image](https://user-images.githubusercontent.com/50696626/174008096-21a550be-4eb9-42ae-b7f7-f7bdcdc45c35.png)



