### PR TITLE
fix: paint SelectableFragment before text

### DIFF
--- a/lib/src/extended/rendering/paragraph.dart
+++ b/lib/src/extended/rendering/paragraph.dart
@@ -207,6 +207,12 @@ class ExtendedRenderParagraph extends _RenderParagraph
       context.canvas.clipRect(bounds);
     }
 
+    if (_lastSelectableFragments != null) {
+      for (final _SelectableFragment fragment in _lastSelectableFragments!) {
+        fragment.paint(context, offset);
+      }
+    }
+
     // zmtzawqlp
     // clip rect of over flow
     if (_overflowRect != null) {
@@ -275,11 +281,7 @@ class ExtendedRenderParagraph extends _RenderParagraph
       }
       context.canvas.restore();
     }
-    if (_lastSelectableFragments != null) {
-      for (final _SelectableFragment fragment in _lastSelectableFragments!) {
-        fragment.paint(context, offset);
-      }
-    }
+
     super.paint(context, offset);
   }
 


### PR DESCRIPTION
Same fix as in Flutter: https://github.com/flutter/flutter/pull/128375

Before:
<img width="1255" alt="obraz" src="https://github.com/fluttercandies/extended_text/assets/17098134/2e2d2050-90c8-41ea-b0d0-5d7f8c93e61b">

After:
<img width="1255" alt="obraz" src="https://github.com/fluttercandies/extended_text/assets/17098134/9d70e8c9-c044-4c82-9625-d3db1b105be6">
