### PR TITLE
fix: getFullHeightForCaret double error

### DIFF
--- a/lib/src/official/rendering/paragraph.dart
+++ b/lib/src/official/rendering/paragraph.dart
@@ -388,7 +388,7 @@ class _RenderParagraph extends RenderBox
 
   Offset _getOffsetForPosition(TextPosition position) {
     return getOffsetForCaret(position, Rect.zero) +
-        Offset(0, getFullHeightForCaret(position));
+        Offset(0, getFullHeightForCaret(position) ?? 0);
   }
 
   @override
@@ -720,7 +720,7 @@ class _RenderParagraph extends RenderBox
   /// {@macro flutter.painting.textPainter.getFullHeightForCaret}
   ///
   /// Valid only after [layout].
-  double getFullHeightForCaret(TextPosition position) {
+  double? getFullHeightForCaret(TextPosition position) {
     assert(!debugNeedsLayout);
     _layoutTextWithConstraints(constraints);
     return _textPainter.getFullHeightForCaret(position, Rect.zero);


### PR DESCRIPTION
<img width="671" alt="image" src="https://github.com/fluttercandies/extended_text/assets/8444646/78a40aa1-0f81-450b-8ccf-d4dd4e57bde0">
