### PR TITLE
Implement content length and selection methods for SelectableFragment[FLUTTER 3.29]

### DIFF
--- a/lib/src/official/rendering/paragraph.dart
+++ b/lib/src/official/rendering/paragraph.dart
@@ -3322,4 +3322,18 @@ class _SelectableFragment
     properties.add(DiagnosticsProperty<TextRange>('range', range));
     properties.add(DiagnosticsProperty<String>('fullText', fullText));
   }
+  
+  @override
+  int get contentLength => fullText.length;
+  
+  @override
+  SelectedContentRange? getSelection() {
+    if (_textSelectionStart == null || _textSelectionEnd == null) {
+      return null;
+    }
+    return SelectedContentRange(
+      startOffset: _textSelectionStart!.offset,
+      endOffset: _textSelectionEnd!.offset,
+    );
+  }
 }


### PR DESCRIPTION
This pull request includes changes to the `class _SelectableFragment` in the `lib/src/official/rendering/paragraph.dart` file. The most important changes include adding a new getter for `contentLength` and implementing the `getSelection` method to return the selected content range.

New methods added:

* [`lib/src/official/rendering/paragraph.dart`](diffhunk://#diff-86b119cbc003fdc116cee1c6c2ab5314feaa59622051f9b9f30ae841eefcfd6bR3325-R3338): Added a getter `contentLength` to return the length of `fullText`.
* [`lib/src/official/rendering/paragraph.dart`](diffhunk://#diff-86b119cbc003fdc116cee1c6c2ab5314feaa59622051f9b9f30ae841eefcfd6bR3325-R3338): Implemented the `getSelection` method to return a `SelectedContentRange` if `_textSelectionStart` and `_textSelectionEnd` are not null.